### PR TITLE
Upgrade mongodb and minimatch from deprecated versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "body-parser": "~1.14.1",
     "concat-stream": "^1.5.2",
-    "connect-mongo": "~0.8.2",
+    "connect-mongo": "^1.3.2",
     "cookie-parser": "~1.4.0",
     "cookie-session": "~1.2.0",
     "express": "~4.13.3",
@@ -23,7 +23,7 @@
     "hyperrequest": "^0.1.1",
     "is-valid-email": "0.0.2",
     "jsonwebtoken": "^5.7.0",
-    "mongoose": "^4.4.12",
+    "mongoose": "^4.11.12",
     "morgan": "^1.7.0",
     "passport": "~0.3.2",
     "passport-facebook": "~2.0.0",


### PR DESCRIPTION
Resolves

```
npm WARN deprecated mongodb@2.0.55: Please upgrade to 2.2.19 or higher
npm WARN deprecated minimatch@0.3.0: Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue
```